### PR TITLE
Add trajectory saving if present as ros param

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(orb_slam3_ros_wrapper)
 
 # Change this to your installation of ORB-SLAM3. Default is ~/
 set(ORB_SLAM3_DIR
-   $ENV{HOME}/Packages/ORB_SLAM3
+   /ORB_SLAM3
 )
 
 set(CMAKE_BUILD_TYPE "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,15 @@ target_link_libraries(${PROJECT_NAME}_stereo
    ${LIBS}
 )
 
+# stereo node (replay)
+add_executable (${PROJECT_NAME}_stereo_replay
+   src/replay_stereo_node.cc
+   src/common.cc
+)
+target_link_libraries(${PROJECT_NAME}_stereo_replay
+   ${LIBS}
+)
+
 
 # mono-inertial node
 add_executable (${PROJECT_NAME}_mono_inertial

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -g")
 find_package (catkin REQUIRED COMPONENTS
    roscpp
    rospy
+   rosbag
    std_msgs
    cv_bridge
    image_transport

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ROS wrapper for ORB-SLAM3
 
+> **NOTE:** The example here uses a [fork of ORB-SLAM3](https://github.com/tianyilim/ORB_SLAM3) which contains some utilities for measuring memory usage of the Linux process for benchmarking purposes.
+
 A ROS wrapper for [ORB-SLAM3](https://github.com/UZ-SLAMLab/ORB_SLAM3). The main idea is to use the ORB-SLAM3 as a standalone library and interface with it instead of putting everything together. For that, you can check out [this package](https://github.com/thien94/orb_slam_3_ros).
 
 Tested with ORB-SLAM3 V1.0, primarily on Ubuntu 20.04.

--- a/include/common.h
+++ b/include/common.h
@@ -28,6 +28,7 @@
 // ORB-SLAM3-specific libraries. Directory is defined in CMakeLists.txt: ${ORB_SLAM3_DIR}
 #include "include/System.h"
 #include "include/ImuTypes.h"
+#include "include/memUsage.h"
 
 extern ORB_SLAM3::System::eSensor sensor_type;
 extern std::string world_frame_id, cam_frame_id, imu_frame_id;

--- a/src/mono_inertial_node.cc
+++ b/src/mono_inertial_node.cc
@@ -48,9 +48,10 @@ int main(int argc, char **argv)
     std::string node_name = ros::this_node::getName();
     image_transport::ImageTransport image_transport(node_handler);
 
-    std::string voc_file, settings_file;
+    std::string voc_file, settings_file, traj_save_file;
     node_handler.param<std::string>(node_name + "/voc_file", voc_file, "file_not_set");
     node_handler.param<std::string>(node_name + "/settings_file", settings_file, "file_not_set");
+    node_handler.param<std::string>(node_name + "/traj_save_file", traj_save_file, "");
 
     if (voc_file == "file_not_set" || settings_file == "file_not_set")
     {
@@ -79,7 +80,16 @@ int main(int argc, char **argv)
 
     std::thread sync_thread(&ImageGrabber::SyncWithImu, &igb);
 
-    ros::spin();
+    while (ros::ok())
+    {
+        ros::spin();
+    }
+
+    // Save trajectory if requested
+    if (traj_save_file != "")
+    {
+        SLAM.SaveTrajectoryTUM(traj_save_file);
+    }
 
     // Stop all threads
     SLAM.Shutdown();

--- a/src/mono_inertial_node.cc
+++ b/src/mono_inertial_node.cc
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
     // Save trajectory if requested
     if (traj_save_file != "")
     {
-        SLAM.SaveTrajectoryTUM(traj_save_file);
+        SLAM.SaveKeyFrameTrajectoryTUM(traj_save_file);
     }
 
     // Stop all threads
@@ -112,7 +112,7 @@ void ImageGrabber::TrajSaveCallback(const ros::TimerEvent &e)
     }
 
     ROS_DEBUG("Attempting to save current traj to file...");
-    mpSLAM->SaveTrajectoryTUM(traj_save_file);
+    mpSLAM->SaveKeyFrameTrajectoryTUM(traj_save_file);
 }
 
 void ImageGrabber::GrabImage(const sensor_msgs::ImageConstPtr &img_msg)

--- a/src/mono_inertial_node.cc
+++ b/src/mono_inertial_node.cc
@@ -21,17 +21,21 @@ public:
 class ImageGrabber
 {
 public:
-    ImageGrabber(ORB_SLAM3::System* pSLAM, ImuGrabber *pImuGb): mpSLAM(pSLAM), mpImuGb(pImuGb){}
+    ImageGrabber(ORB_SLAM3::System* pSLAM, ImuGrabber *pImuGb, const std::string& traj_save_file_): mpSLAM(pSLAM), mpImuGb(pImuGb), traj_save_file(traj_save_file_){}
+
 
     void GrabImage(const sensor_msgs::ImageConstPtr& msg);
     cv::Mat GetImage(const sensor_msgs::ImageConstPtr &img_msg);
     void SyncWithImu();
+
+    void TrajSaveCallback(const ros::TimerEvent &e);
 
     queue<sensor_msgs::ImageConstPtr> img0Buf;
     std::mutex mBufMutex;
    
     ORB_SLAM3::System* mpSLAM;
     ImuGrabber *mpImuGb;
+    const std::string traj_save_file;
 };
 
 
@@ -71,13 +75,15 @@ int main(int argc, char **argv)
     ORB_SLAM3::System SLAM(voc_file, settings_file, sensor_type, enable_pangolin);
 
     ImuGrabber imugb;
-    ImageGrabber igb(&SLAM, &imugb);
+    ImageGrabber igb(&SLAM, &imugb, traj_save_file);
 
     ros::Subscriber sub_imu = node_handler.subscribe("/imu", 1000, &ImuGrabber::GrabImu, &imugb); 
     ros::Subscriber sub_img0 = node_handler.subscribe("/camera/image_raw", 100, &ImageGrabber::GrabImage, &igb);
 
     setup_ros_publishers(node_handler, image_transport);
-
+    
+    // Timer callback to save trajectory every few seconds
+    ros::Timer timer = node_handler.createTimer(ros::Duration(5.0), &ImageGrabber::TrajSaveCallback, &igb);
     std::thread sync_thread(&ImageGrabber::SyncWithImu, &igb);
 
     while (ros::ok())
@@ -96,6 +102,17 @@ int main(int argc, char **argv)
     ros::shutdown();
 
     return 0;
+}
+
+void ImageGrabber::TrajSaveCallback(const ros::TimerEvent &e)
+{
+    if (traj_save_file == "")
+    {
+        return;
+    }
+
+    ROS_DEBUG("Attempting to save current traj to file...");
+    mpSLAM->SaveTrajectoryTUM(traj_save_file);
 }
 
 void ImageGrabber::GrabImage(const sensor_msgs::ImageConstPtr &img_msg)

--- a/src/mono_node.cc
+++ b/src/mono_node.cc
@@ -31,9 +31,10 @@ int main(int argc, char **argv)
     std::string node_name = ros::this_node::getName();
     image_transport::ImageTransport image_transport(node_handler);
 
-    std::string voc_file, settings_file;
+    std::string voc_file, settings_file, traj_save_file;
     node_handler.param<std::string>(node_name + "/voc_file", voc_file, "file_not_set");
     node_handler.param<std::string>(node_name + "/settings_file", settings_file, "file_not_set");
+    node_handler.param<std::string>(node_name + "/traj_save_file", traj_save_file, "");
 
     if (voc_file == "file_not_set" || settings_file == "file_not_set")
     {
@@ -66,11 +67,19 @@ int main(int argc, char **argv)
 
     setup_ros_publishers(node_handler, image_transport, rpy_rad);
 
-    ros::spin();
+    while (ros::ok())
+    {
+        ros::spin();
+    }
+
+    // Save trajectory if requested
+    if (traj_save_file != "")
+    {
+        SLAM.SaveTrajectoryTUM(traj_save_file);
+    }
 
     // Stop all threads
     SLAM.Shutdown();
-
     ros::shutdown();
 
     return 0;

--- a/src/replay_stereo_node.cc
+++ b/src/replay_stereo_node.cc
@@ -1,0 +1,227 @@
+/*******************************************************
+Directly process from a rosbag, for the stereo case only.
+
+Adapted from ORB-SLAM3: Examples/ROS/src/ros_stereo.cc
+
+ *******************************************************/
+#include <ros/ros.h>
+#include <rosbag/bag.h>
+#include <rosbag/view.h>
+#include <sensor_msgs/Image.h>
+
+#include "common.h"
+
+using namespace std;
+
+class ImageGrabber {
+   public:
+    ImageGrabber(ORB_SLAM3::System* pSLAM) : mpSLAM(pSLAM) {}
+
+    void GrabLeft(const sensor_msgs::ImageConstPtr& msgLeft);
+    void GrabRight(const sensor_msgs::ImageConstPtr& msgRight);
+
+    void GrabStereo(const sensor_msgs::ImageConstPtr& msgLeft,
+                    const sensor_msgs::ImageConstPtr& msgRight);
+
+    ORB_SLAM3::System* mpSLAM;
+    cv::Mat M1l, M2l, M1r, M2r;
+
+    sensor_msgs::ImageConstPtr left_image, right_image;
+};
+
+void ImageGrabber::GrabLeft(const sensor_msgs::ImageConstPtr& msgLeft)
+{
+    left_image = msgLeft;
+    if (right_image) {
+        const auto time_diff_s =
+            abs(right_image->header.stamp.toSec() - left_image->header.stamp.toSec());
+        if (time_diff_s > 0.01) {
+            ROS_INFO("Time diff %0.3f s, skipping", time_diff_s);
+            return;
+        }
+
+        GrabStereo(left_image, right_image);
+    }
+
+    left_image = nullptr;
+    right_image = nullptr;
+}
+
+void ImageGrabber::GrabRight(const sensor_msgs::ImageConstPtr& msgRight)
+{
+    right_image = msgRight;
+    if (left_image) {
+        const auto time_diff_s =
+            abs(right_image->header.stamp.toSec() - left_image->header.stamp.toSec());
+        if (time_diff_s > 0.01) {
+            ROS_INFO("Time diff %0.3f s, skipping", time_diff_s);
+            return;
+        }
+
+        GrabStereo(left_image, right_image);
+    }
+
+    left_image = nullptr;
+    right_image = nullptr;
+}
+
+void ImageGrabber::GrabStereo(const sensor_msgs::ImageConstPtr& msgLeft,
+                              const sensor_msgs::ImageConstPtr& msgRight)
+{
+    // Copy the ros image message to cv::Mat.
+    cv_bridge::CvImageConstPtr cv_ptrLeft;
+    try {
+        cv_ptrLeft = cv_bridge::toCvShare(msgLeft);
+    }
+    catch (cv_bridge::Exception& e) {
+        ROS_ERROR("cv_bridge exception: %s", e.what());
+        return;
+    }
+
+    cv_bridge::CvImageConstPtr cv_ptrRight;
+    try {
+        cv_ptrRight = cv_bridge::toCvShare(msgRight);
+    }
+    catch (cv_bridge::Exception& e) {
+        ROS_ERROR("cv_bridge exception: %s", e.what());
+        return;
+    }
+
+    // Main algorithm runs here
+    Sophus::SE3f Tcc0 = mpSLAM->TrackStereo(cv_ptrLeft->image, cv_ptrRight->image,
+                                            cv_ptrLeft->header.stamp.toSec());
+    Sophus::SE3f Twc = (Tcc0 * Tc0w).inverse();
+
+    ros::Time msg_time = cv_ptrLeft->header.stamp;
+
+    publish_ros_camera_pose(Twc, msg_time);
+    publish_ros_tf_transform(Twc, world_frame_id, cam_frame_id, msg_time);
+    publish_ros_tracked_mappoints(mpSLAM->GetTrackedMapPoints(), msg_time);
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        ROS_ERROR(
+            "Usage: rosrun orbslam_ros_wrapper orb_slam3_ros_wrapper_stereo_replay "
+            "[rosbag_path]\n");
+
+        for (int i = 0; i < argc; i++) {
+            ROS_ERROR("argv[%d]: %s\n", i, argv[i]);
+        }
+
+        return 1;
+    }
+
+    ros::init(argc, argv, "orbslam3_ros_wrapper_stereo_replay");
+    ros::NodeHandle node_handler;
+    std::string node_name = ros::this_node::getName();
+    ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Info);
+
+    // Read params from roslaunch
+    std::string voc_file, settings_file, traj_save_file, rosbag_path;
+    std::string left_cam_topic, right_cam_topic;
+    node_handler.param<std::string>(node_name + "/voc_file", voc_file, "file_not_set");
+    node_handler.param<std::string>(node_name + "/settings_file", settings_file, "file_not_set");
+    node_handler.param<std::string>(node_name + "/traj_save_file", traj_save_file, "");
+    node_handler.param<std::string>(node_name + "/rosbag_path", rosbag_path, "");
+    node_handler.param<std::string>(node_name + "/left_cam_topic", left_cam_topic, "");
+    node_handler.param<std::string>(node_name + "/right_cam_topic", right_cam_topic, "");
+
+    if (voc_file == "file_not_set" || settings_file == "file_not_set") {
+        ROS_ERROR("Please provide voc_file and settings_file in the launch file");
+        ros::shutdown();
+        return 1;
+    }
+
+    if (rosbag_path == "") {
+        ROS_ERROR("Please provide rosbag_path in the launch file");
+        ros::shutdown();
+        return 1;
+    }
+
+    if (left_cam_topic == "" || right_cam_topic == "") {
+        ROS_ERROR("Please provide left_cam_topic and right_cam_topic in the launch file");
+        ros::shutdown();
+        return 1;
+    }
+
+    node_handler.param<std::string>(node_name + "/world_frame_id", world_frame_id, "map");
+    node_handler.param<std::string>(node_name + "/cam_frame_id", cam_frame_id, "camera");
+
+    bool enable_pangolin;
+    node_handler.param<bool>(node_name + "/enable_pangolin", enable_pangolin, true);
+
+    // World frame orientation
+    Eigen::Vector3d rpy_rad;
+    std::string angle_names[3] = {"roll", "pitch", "yaw"};
+    for (int i = 0; i < 3; i++) {
+        node_handler.param<double>(node_name + "/world_" + angle_names[i], rpy_rad(i), 0);
+    }
+
+    // Create SLAM system. It initializes all system threads and gets ready to process frames.
+    sensor_type = ORB_SLAM3::System::STEREO;
+    ORB_SLAM3::System SLAM(voc_file, settings_file, sensor_type, enable_pangolin);
+    ImageGrabber igb(&SLAM);
+
+    ROS_INFO("Opening rosbag: %s", rosbag_path.c_str());
+    // Open rosbag
+    rosbag::Bag bag;
+    bag.open(rosbag_path, rosbag::bagmode::Read);
+
+    // TODO Setup ROS publishers for the relevant topcis
+    // registerPub(n);
+    // ros::Publisher pubLeftImage = n.advertise<sensor_msgs::Image>(IMAGE0_TOPIC, 1000);
+    // ros::Publisher pubRightImage = n.advertise<sensor_msgs::Image>(IMAGE1_TOPIC, 1000);
+
+    // Read topics from rosbag
+    std::vector<std::string> topics_to_read;
+    topics_to_read.push_back(std::string(left_cam_topic));
+    topics_to_read.push_back(std::string(right_cam_topic));
+    rosbag::View view(bag, rosbag::TopicQuery(topics_to_read));
+
+    // Check if we are faster than just rosbag play :)
+    auto time_start = std::chrono::high_resolution_clock::now();
+
+    for (rosbag::MessageInstance const m : view) {
+        // ROS_DEBUG("Read topic [%s]", m.getTopic().c_str());
+        if (!ros::ok()) {
+            break;
+        }
+
+        if (m.getTopic() == std::string(left_cam_topic)) {
+            sensor_msgs::ImageConstPtr img_msg = m.instantiate<sensor_msgs::Image>();
+            igb.GrabLeft(img_msg);
+        }
+        else if (m.getTopic() == std::string(right_cam_topic)) {
+            sensor_msgs::ImageConstPtr img_msg = m.instantiate<sensor_msgs::Image>();
+            igb.GrabRight(img_msg);
+        }
+        else {
+            ROS_WARN("Ignoring topic %s", m.getTopic().c_str());
+            continue;
+        }
+    }
+
+    auto time_end = std::chrono::high_resolution_clock::now();
+    auto duration_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(time_end - time_start).count();
+    ROS_WARN("Loop duration: %0.2fd ms | Effective freq: %0.2f Hz", duration_ms,
+             1000.0 / duration_ms);
+
+    bag.close();
+
+    // Save trajectory if requested
+    if (traj_save_file != "") {
+        ROS_INFO("Saving trajectory to %s", traj_save_file.c_str());
+        SLAM.SaveTrajectoryTUM(traj_save_file);
+    }
+    else {
+        ROS_INFO("Trajectory file not provided, not saved");
+    }
+
+    SLAM.Shutdown();
+    ros::shutdown();
+
+    return 0;
+}

--- a/src/replay_stereo_node.cc
+++ b/src/replay_stereo_node.cc
@@ -101,18 +101,6 @@ void ImageGrabber::GrabStereo(const sensor_msgs::ImageConstPtr& msgLeft,
 
 int main(int argc, char** argv)
 {
-    if (argc < 2) {
-        ROS_ERROR(
-            "Usage: rosrun orbslam_ros_wrapper orb_slam3_ros_wrapper_stereo_replay "
-            "[rosbag_path]\n");
-
-        for (int i = 0; i < argc; i++) {
-            ROS_ERROR("argv[%d]: %s\n", i, argv[i]);
-        }
-
-        return 1;
-    }
-
     ros::init(argc, argv, "orbslam3_ros_wrapper_stereo_replay");
     ros::NodeHandle node_handler;
     std::string node_name = ros::this_node::getName();

--- a/src/replay_stereo_node.cc
+++ b/src/replay_stereo_node.cc
@@ -169,11 +169,17 @@ int main(int argc, char** argv)
 
     // Check if we are faster than just rosbag play :)
     auto time_start = std::chrono::high_resolution_clock::now();
+    const float bag_start_time = view.getBeginTime().toSec();
+    const float bag_end_time = view.getEndTime().toSec();
+    const float bag_duration = bag_end_time - bag_start_time;
 
     for (rosbag::MessageInstance const m : view) {
         if (!ros::ok()) {
             break;
         }
+
+        const float curr_msg_time = m.getTime().toSec();
+        ROS_INFO_THROTTLE(1, "Time: %0.3f / %0.3fs", curr_msg_time - bag_start_time, bag_duration);
 
         if (m.getTopic() == std::string(left_cam_topic)) {
             sensor_msgs::ImageConstPtr img_msg = m.instantiate<sensor_msgs::Image>();

--- a/src/rgbd_node.cc
+++ b/src/rgbd_node.cc
@@ -31,9 +31,10 @@ int main(int argc, char **argv)
     std::string node_name = ros::this_node::getName();
     image_transport::ImageTransport image_transport(node_handler);
 
-    std::string voc_file, settings_file;
+    std::string voc_file, settings_file, traj_save_file;
     node_handler.param<std::string>(node_name + "/voc_file", voc_file, "file_not_set");
     node_handler.param<std::string>(node_name + "/settings_file", settings_file, "file_not_set");
+    node_handler.param<std::string>(node_name + "/traj_save_file", traj_save_file, "");
 
     if (voc_file == "file_not_set" || settings_file == "file_not_set")
     {
@@ -62,11 +63,19 @@ int main(int argc, char **argv)
 
     setup_ros_publishers(node_handler, image_transport);
 
-    ros::spin();
+    while (ros::ok())
+    {
+        ros::spin();
+    }
+
+    // Save trajectory if requested
+    if (traj_save_file != "")
+    {
+        SLAM.SaveTrajectoryTUM(traj_save_file);
+    }
 
     // Stop all threads
     SLAM.Shutdown();
-
     ros::shutdown();
 
     return 0;

--- a/src/stereo_inertial_node.cc
+++ b/src/stereo_inertial_node.cc
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
     // Save trajectory if requested
     if (traj_save_file != "")
     {
-        SLAM.SaveTrajectoryTUM(traj_save_file);
+        SLAM.SaveKeyFrameTrajectoryTUM(traj_save_file);
     }
 
     // Stop all threads
@@ -113,7 +113,7 @@ void ImageGrabber::TrajSaveCallback(const ros::TimerEvent &e)
     }
 
     ROS_DEBUG("Attempting to save current traj to file...");
-    mpSLAM->SaveTrajectoryTUM(traj_save_file);
+    mpSLAM->SaveKeyFrameTrajectoryTUM(traj_save_file);
 }
 
 void ImageGrabber::GrabImageLeft(const sensor_msgs::ImageConstPtr &img_msg)

--- a/src/stereo_inertial_node.cc
+++ b/src/stereo_inertial_node.cc
@@ -48,9 +48,10 @@ int main(int argc, char **argv)
     std::string node_name = ros::this_node::getName();
     image_transport::ImageTransport image_transport(node_handler);
 
-    std::string voc_file, settings_file;
+    std::string voc_file, settings_file, traj_save_file;
     node_handler.param<std::string>(node_name + "/voc_file", voc_file, "file_not_set");
     node_handler.param<std::string>(node_name + "/settings_file", settings_file, "file_not_set");
+    node_handler.param<std::string>(node_name + "/traj_save_file", traj_save_file, "");
 
     if (voc_file == "file_not_set" || settings_file == "file_not_set")
     {
@@ -80,7 +81,20 @@ int main(int argc, char **argv)
 
     std::thread sync_thread(&ImageGrabber::SyncWithImu, &igb);
 
-    ros::spin();
+    while (ros::ok())
+    {
+        ros::spin();
+    }
+
+    // Save trajectory if requested
+    if (traj_save_file != "")
+    {
+        SLAM.SaveTrajectoryTUM(traj_save_file);
+    }
+
+    // Stop all threads
+    SLAM.Shutdown();
+    ros::shutdown();
 
     return 0;
 }

--- a/src/stereo_node.cc
+++ b/src/stereo_node.cc
@@ -32,9 +32,10 @@ int main(int argc, char **argv)
     std::string node_name = ros::this_node::getName();
     image_transport::ImageTransport image_transport(node_handler);
 
-    std::string voc_file, settings_file;
+    std::string voc_file, settings_file, traj_save_file;
     node_handler.param<std::string>(node_name + "/voc_file", voc_file, "file_not_set");
     node_handler.param<std::string>(node_name + "/settings_file", settings_file, "file_not_set");
+    node_handler.param<std::string>(node_name + "/traj_save_file", traj_save_file, "");
 
     if (voc_file == "file_not_set" || settings_file == "file_not_set")
     {
@@ -70,7 +71,16 @@ int main(int argc, char **argv)
 
     setup_ros_publishers(node_handler, image_transport, rpy_rad);
 
-    ros::spin();
+    while (ros::ok())
+    {
+        ros::spin();
+    }
+
+    // Save trajectory if requested
+    if (traj_save_file != "")
+    {
+        SLAM.SaveTrajectoryTUM(traj_save_file);
+    }
 
     // Stop all threads
     SLAM.Shutdown();


### PR DESCRIPTION
It would be useful to automatically save the camera trajectory when the ROS node is shut down. This PR impelments it. 

I tested with the stereo_inertial and mono_inertial nodes.